### PR TITLE
[BUGFIX] Add requirement for `typo3/cms-core`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
     "bk2k/bootstrap-package": "^12.0",
     "georgringer/news":"^9.4",
     "reelworx/rx-shariff":"^14",
-    "apache-solr-for-typo3/solr": "^11.5@RC"
+    "apache-solr-for-typo3/solr": "^11.5@RC",
+    "typo3/cms-core": "~11.5.0"
   },
   "autoload": {
     "psr-4": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -19,6 +19,7 @@ $EM_CONF[$_EXTKEY] = [
     ],
     'constraints' => [
         'depends' => [
+            'typo3' => '11.5.0-11.5.99',
             'news' => '9.4.0-9.99.99',
             'bootstrap_package' => '12.0.0-12.99.99',
             'rx_shariff' => '14.0.0-14.99.99',

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -19,9 +19,9 @@ $EM_CONF[$_EXTKEY] = [
     ],
     'constraints' => [
         'depends' => [
-            'news' => '9.4.0-0.0.0.',
-            'bootstrap_package' => '12.0.0-0.0.0.',
-            'rx_shariff' => '14.0.0-0.0.0.',
+            'news' => '9.4.0-9.99.99',
+            'bootstrap_package' => '12.0.0-12.99.99',
+            'rx_shariff' => '14.0.0-14.99.99',
         ],
         'conflicts' => [],
         'suggests' => [


### PR DESCRIPTION
This PR adds the missing requirement for `typo3/cms-core` to both `composer.json` and `ext_emconf.php`.